### PR TITLE
修正hascode初始化值

### DIFF
--- a/src/Luy/vdom.js
+++ b/src/Luy/vdom.js
@@ -72,7 +72,7 @@ function updateChild(oldChild, newChild, parentDomNode: Element, parentContext) 
         newStartVnode = newChild[0],
         oldEndVnode = oldChild[oldEndIndex],
         newEndVnode = newChild[newEndIndex],
-        hascode = {};
+        hascode;
 
     if (newLength >= 0 && !oldLength) {
         newChild.forEach((newVnode, index) => {


### PR DESCRIPTION
hascode={}会导致if (hascode === undefined) hascode = mapKeyToIndex(oldChild)  无法执行生成key映射